### PR TITLE
test: Fix “mirror npm defaults” test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '14'
   - '12'
   - '10'

--- a/index.js
+++ b/index.js
@@ -68,4 +68,9 @@ module.exports = (opts, types, defaults) => {
 	return conf;
 };
 
-module.exports.defaults = Object.assign({}, _defaults.defaults);
+Object.defineProperty(module.exports, 'defaults', {
+	get() {
+		return _defaults.defaults;
+	},
+	enumerable: true
+})

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"babylon": "^6.17.1",
 		"eslint-import-resolver-node": "^0.3.2",
 		"jest": "^25.1.0",
-		"npm": "^5.0.4",
-		"pify": "^4.0.1"
+		"npm": "^5.0.4"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,19 +1,23 @@
+// load `npmDefaults` first and clone them into a new object as `npmCore` mutates them
+const npmDefaults = Object.assign({}, require('./node_modules/npm/lib/config/defaults').defaults);
 const npmCore = require('npm/lib/config/core');
-const npmDefaults = require('npm/lib/config/defaults');
-const pify = require('pify');
+const { promisify } = require('util');
 const m = require('.');
+
+// The 'unicode' property is determined based on OS type and environment variables
+delete npmDefaults.unicode;
 
 test('mirror npm config', async () => {
 	const conf = m();
-	const npmconf = await pify(npmCore.load)();
+	const npmConf = await promisify(npmCore.load)();
 
-	expect(conf.globalPrefix).toBe(npmconf.globalPrefix);
-	expect(conf.localPrefix).toBe(npmconf.localPrefix);
-	expect(conf.get('prefix')).toBe(npmconf.get('prefix'));
-	expect(conf.get('registry')).toBe(npmconf.get('registry'));
-	expect(conf.get('tmp')).toBe(npmconf.get('tmp'));
+	expect(conf.globalPrefix).toBe(npmConf.globalPrefix);
+	expect(conf.localPrefix).toBe(npmConf.localPrefix);
+	expect(conf.get('prefix')).toBe(npmConf.get('prefix'));
+	expect(conf.get('registry')).toBe(npmConf.get('registry'));
+	expect(conf.get('tmp')).toBe(npmConf.get('tmp'));
 });
 
-test.skip('mirror npm defaults', () => {
-	expect(m.defaults).toBe(npmDefaults.defaults);
+test('mirror npm defaults', () => {
+	expect(m.defaults).toMatchObject(npmDefaults);
 });


### PR DESCRIPTION
This fixes the “mirror npm defaults” test, so that it passes.

It also switches the test code to use **Node**’s built‑in `util.promisify` instead of `pify`.