### PR TITLE
chore: Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ node_js:
   - '14'
   - '12'
   - '10'
+
+before_install:
+  - curl -L https://unpkg.com/@pnpm/self-installer | node
+
+install:
+  - pnpm install
+
+script:
+  - pnpm test


### PR DESCRIPTION
Because `devDependencies` contains `npm: "^5.0.4"`, **Travis CI** ends up using **npm v5**, which doesn’t work on **Node v14**.

This makes **Travis CI** use **pnpm** instead.