### PR TITLE
Fix: throw if not ENOENT

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -41,7 +41,11 @@ class Conf extends ConfigChain {
 			const contents = fs.readFileSync(file, 'utf8');
 			this.addString(contents, file, 'ini', marker);
 		} catch (error) {
-			this.add({}, marker);
+			if (error.code === 'ENOENT') {
+				this.add({}, marker);
+			} else {
+				throw error;
+			}
 		}
 
 		return this;


### PR DESCRIPTION
We had a tricky bug at work using pnpm as it seemed to not read publicHoistPattern on some users' machines.
We worked out that it wasn't using or finding the .npmrc file. After lots of debugging we worked out that it should be loading the file but the settings were still empty/default.

I logged out the error that is swallowed on this line and I found:
```
Error: Failed to replace env in config: ${GITHUB_TOKEN}
``` 
I can understand the ENOENT errors being ignored since in many cases you're loading files that may not have been created, but in this case we were failing to interpolate an env variable and had no idea that was the issue. Since this was so painful to track down, I wanted to make a PR to try to improve the situation for anyone else.

Maybe there's a reason why these errors are always swallowed even if they're not ENOENT, but I can't imagine why. Still, I imagine this is a breaking change so I'm happy to discuss it. But the fact that it's swallowed at the npm-conf level means there's really nothing to PR against in the main repo.