### PR TITLE
fix: add warning while loading npm buildin configs fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ module.exports = (opts, types, defaults) => {
 		try {
 			npmPath = require.resolve('npm', {paths: paths.slice(-1)});
 		} catch (error) {
-			// Error will be thrown if module cannot be found.
-			// We should ignore that error.
+			// If npm module cannot be found, add warning about adding global config to overwrite builtin config
+			warnings.push('Load npm builtin configs failed, you can use "pnpm config ls" to show builtin configs. And then use "pnpm config --global set <key> <value>" to migrate configs from builtin to global.');
 		}
 
 		if (npmPath) {

--- a/test.js
+++ b/test.js
@@ -22,3 +22,15 @@ test('mirror npm defaults', () => {
 	delete npmDefaults['node-version']
 	expect(m.defaults).toMatchObject(npmDefaults);
 });
+
+
+test('npm builtin configs require failed', async () => {
+	const expected = [
+		expect.stringMatching(/Load npm builtin configs failed/),
+	];
+
+	// In the scope of jest, require.resolve.paths('npm') cannot reach global npm path by default
+	const { warnings } = m();
+	
+	expect(warnings).toEqual(expect.arrayContaining(expected));
+})


### PR DESCRIPTION
Use npm root instead of require resolve npm, close https://github.com/pnpm/pnpm/issues/5404.

From the [npm/cli](https://github.com/npm/cli/blob/latest/lib/npm.js#L54) we can see `npm` use `path.dirname(__dirname)` to define `npmPath`. But in `pnpm/npm-conf` we need to locate where `npm` is to infer built-in npm path.

```javascript
const paths = require.resolve.paths('npm');
// Assume that last path in resolve paths is builtin modules directory
let npmPath;
try {
	npmPath = require.resolve('npm', {paths: paths.slice(-1)});
} catch (error) {
	// Error will be thrown if module cannot be found.
	// We should ignore that error.
}
```
The source code above works fine in most situations. But npm installed by homebrew will bring a default npmrc in built-in config to define your npm prefix by using homebrew prefix:
```
prefix=$HOMEBREW_PREFIX
```
And in this scene, `npm` module cannot be found by `require.resolve('npm', {paths: paths.slice(-1)})`. 

- common cases:  `/opt/nodejs/x.x.x/lib/node` will try to resolve`/opt/nodejs/x.x.x/lib/node_modules/npm`
- with homebrew: `$HOMEBREW_PREFIX/Cellar/node/x.x.x/lib/node` will try to resolve `$HOMEBREW_PREFIX/Cellar/node/x.x.x/lib/node_modules/npm` but the directory doesn't exist and actually the npm is under `$HOMEBREW_PREFIX/lib/node_modules/npm`. Since npmPath is `undefined` and built-in confgs are ignored, default prefix will always be `$HOMEBREW_PREFIX/Cellar/node/x.x.x`, [source code here](https://github.com/pnpm/npm-conf/blob/main/lib/defaults.js#L46), thus causing the error from this issue and all commands rely on global configs don't work:
> ERROR  Unable to find the global bin directory
Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable. The global bin directory should be in the PATH.

So I think it's better to use `npm root -g` instead of `require.resolve('npm')`, `npm root -g` will always return the global path of npm such as `/opt/nodejs/x.x.x/lib/node_modules` or `$HOMEBREW_PREFIX/lib/node_modules` 

Let me know if there exists any problem. Thanks!