### PR TITLE
feat: add provenance option

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -127,6 +127,7 @@ Object.defineProperty(exports, 'defaults', {
 			production: process.env.NODE_ENV === 'production',
 			'progress': !process.env.TRAVIS && !process.env.CI,
 			proxy: null,
+			provenance: false,
 			'https-proxy': null,
 			'no-proxy': null,
 			'user-agent': 'npm/{npm-version} ' + 'node/{node-version} ' + '{platform} ' + '{arch}',

--- a/lib/make.js
+++ b/lib/make.js
@@ -47,7 +47,12 @@ const cache = path.resolve(cacheRoot, cacheExtra);
 let defaults;
 let globalPrefix;
 
-${body.replace(INDENT_REGEXP, INDENT_REPLACER).replace("'node-version': process.version,", '// We remove node-version to fix the issue described here: https://github.com/pnpm/pnpm/issues/4203#issuecomment-1133872769')};
+${body
+	.replace(INDENT_REGEXP, INDENT_REPLACER)
+	.replace("'node-version': process.version,", '// We remove node-version to fix the issue described here: https://github.com/pnpm/pnpm/issues/4203#issuecomment-1133872769')
+	 // add provenance: https://github.com/pnpm/pnpm/pull/6436
+	.replace("proxy: null,", "proxy: null,\n\t\t\tprovenance: false,")
+};
 `;
 
 /** @param {string} body */
@@ -62,7 +67,11 @@ const Umask = () => {};
 const getLocalAddresses = () => [];
 const semver = () => {};
 
-${body.replace(INDENT_REGEXP, INDENT_REPLACER)};
+${body
+	.replace(INDENT_REGEXP, INDENT_REPLACER)
+	// add provenance: https://github.com/pnpm/pnpm/pull/6436
+	.replace("proxy: [null, false, url],", "proxy: [null, false, url],\n\tprovenance: Boolean,")
+};
 `;
 
 const defaults = require.resolve('npm/lib/config/defaults');

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -79,6 +79,7 @@ export var types: {
     production: BooleanConstructor;
     progress: BooleanConstructor;
     proxy: (boolean | typeof import("url") | null)[];
+    provenance: BooleanConstructor;
     'read-only': BooleanConstructor;
     'rebuild-bundle': BooleanConstructor;
     registry: (typeof import("url") | null)[];

--- a/lib/types.js
+++ b/lib/types.js
@@ -90,6 +90,7 @@ exports.types = {
 	production: Boolean,
 	progress: Boolean,
 	proxy: [null, false, url],
+	provenance: Boolean,
 	// allow proxy to be disabled explicitly
 	'read-only': Boolean,
 	'rebuild-bundle': Boolean,


### PR DESCRIPTION
run `pnpm publish --provenance` with local pnpm package, will throw an unknown option error:

```
$ node /Users/await-ovo/Documents/projects/pnpm/pnpm/bin/pnpm.cjs publish --provenance
 ERROR   ERROR  Unknown option: 'provenance'
Did you mean 'parseable'? Use "--config.unknown=value" to force an unknown option.
For help, run: pnpm help publish

```

