### PR TITLE
fix: don't crash when APPDATA is undefined on Windows

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -26,7 +26,7 @@ if (home) {
 }
 
 const cacheExtra = process.platform === 'win32' ? 'npm-cache' : '.npm';
-const cacheRoot = process.platform === 'win32' ? process.env.APPDATA : home;
+const cacheRoot = process.platform === 'win32' && process.env.APPDATA || home;
 const cache = path.resolve(cacheRoot, cacheExtra);
 
 let defaults;


### PR DESCRIPTION
ref https://github.com/pnpm/pnpm/issues/6659