### PR TITLE
Substitute environment vars in config keys

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -17,8 +17,10 @@ class Conf extends ConfigChain {
 	// https://github.com/npm/cli/blob/latest/lib/config/core.js#L326-L338
 	add(data, marker) {
 		try {
-			for (const x of Object.keys(data)) {
-				data[x] = this._parseField(data[x], x);
+			for (const [key, value] of Object.entries(data)) {
+				delete data[key];
+				const substKey = util.parseKey(key);
+				data[substKey] = this._parseField(value, substKey);
 			}
 		} catch (error) {
 			throw error;

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -18,8 +18,10 @@ class Conf extends ConfigChain {
 	add(data, marker) {
 		try {
 			for (const [key, value] of Object.entries(data)) {
-				delete data[key];
 				const substKey = util.parseKey(key);
+				if (substKey !== key) {
+				  delete data[key];
+				}
 				data[substKey] = this._parseField(value, substKey);
 			}
 		} catch (error) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { envReplace } = require('@pnpm/config.env-replace');
 
 const parseKey = (key) => {
-	if(typeof key !== "string") {
+	if (typeof key !== 'string') {
 		return key;
 	}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,14 @@ const fs = require('fs');
 const path = require('path');
 const { envReplace } = require('@pnpm/config.env-replace');
 
+const parseKey = (key) => {
+	if(typeof key !== "string") {
+		return key;
+	}
+
+	return envReplace(key, process.env)
+}
+
 // https://github.com/npm/cli/blob/latest/lib/config/core.js#L359-L404
 const parseField = (types, field, key) => {
 	if (typeof field !== 'string') {
@@ -127,3 +135,4 @@ const findPrefix = name => {
 exports.envReplace = envReplace;
 exports.findPrefix = findPrefix;
 exports.parseField = parseField;
+exports.parseKey = parseKey;


### PR DESCRIPTION
Allow using env vars in keys as well, e.g.:

```
//${REGISTRY}:_authToken=${TOKEN}
```

Enables pnpm/pnpm#6679 and harmonizes behavior with @npmcli/config (see https://github.com/npm/cli/blob/96c957aaa8a77b413c1b031d26412c2eb9048c3d/workspaces/config/lib/index.js#L582-L583).