### PR TITLE
fix: preserve registry URL in environment key conversion

### DIFF
--- a/lib/envKeyToSetting.js
+++ b/lib/envKeyToSetting.js
@@ -5,7 +5,7 @@ module.exports = function (x) {
 	}
 	const firstPart = x.substr(0, colonIndex);
 	const secondPart = x.substr(colonIndex + 1);
-	return `${normalize(firstPart)}:${normalize(secondPart)}`;
+	return `${firstPart}:${normalize(secondPart)}`;
 }
 
 function normalize (s) {

--- a/lib/envKeyToSetting.test.js
+++ b/lib/envKeyToSetting.test.js
@@ -37,6 +37,10 @@ const fixtures = [
 		'_always_auth',
 		'_always-auth',
 	],
+	[
+		'//pkgs.dev.azure.com/azure-devops-org/_packaging/feed-name/npm/registry/:_authtoken',
+		'//pkgs.dev.azure.com/azure-devops-org/_packaging/feed-name/npm/registry/:_authToken',
+	],
 ];
 
 test('envKeyToSetting()', () => {


### PR DESCRIPTION
When configuring registry authentication through `npm_config_` env vars. `pnpm` cannot authenticate against registries using `_` in the URLs. The URLs are incorrectly transformed replacing `_` with `-` and also lowercasing the path.

`//pkgs.dev.azure.com/azure-devops-org/_packaging/feed-name/npm/registry/:_authtoken` gets normalized to `//pkgs.dev.azure.com/azure-devops-org/-packaging/feed-name/npm/registry/:_authToken`. Notice the `_packaging` to `-packaging` normalization which breaks the url.

Normalization logic update:

* Changed the normalization function to only apply to the second part of the key after the colon, leaving the first part unmodified in `envKeyToSetting.js`.

Test coverage update:

* Added a test case for Azure DevOps registry authentication tokens to ensure correct normalization of the token key in `envKeyToSetting.test.js`.