### PR TITLE
fix: project/workspace .npmrc cannot redirect trusted user/global config

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,27 @@ module.exports = (opts, types, defaults) => {
 	conf.addEnv();
 	conf.loadPrefix();
 
+	// SECURITY: The `project` and `workspace` .npmrc files added to the config
+	// chain below are repository-controlled. They must NOT be able to choose
+	// which files are loaded as the trusted `user` and `global` config sources.
+	// `userconfig`, `globalconfig` and `prefix` decide those destinations, so a
+	// project/workspace .npmrc could otherwise set e.g. `userconfig=.evil` and
+	// have an attacker-supplied, repo-shipped file loaded as trusted `user`
+	// config — which downstream consumers exempt from untrusted-env-expansion
+	// filtering and which may set `tokenHelper` — leaking environment secrets.
+	// Resolve those destinations now, from the trusted layers only (cli, env,
+	// builtin, defaults), before the project/workspace layers are pushed.
+	const trustedUserconfig = conf.get('userconfig');
+	const trustedPrefix = conf.get('prefix');
+	if (trustedPrefix) {
+		const etc = path.resolve(trustedPrefix, 'etc');
+		conf.root.globalconfig = path.resolve(etc, 'npmrc');
+		conf.root.globalignorefile = path.resolve(etc, 'npmignore');
+	}
+	const trustedGlobalconfig = conf.get('globalconfig');
+
 	const projectConf = path.resolve(conf.localPrefix, '.npmrc');
-	const userConf = conf.get('userconfig');
+	const userConf = trustedUserconfig;
 
 	if (!conf.get('global') && projectConf !== userConf) {
 		warnings.push(conf.addFile(projectConf, 'project'));
@@ -51,15 +70,9 @@ module.exports = (opts, types, defaults) => {
 		warnings.push(conf.addFile(workspaceConf, 'workspace'));
 	}
 
-	warnings.push(conf.addFile(conf.get('userconfig'), 'user'));
+	warnings.push(conf.addFile(trustedUserconfig, 'user'));
 
-	if (conf.get('prefix')) {
-		const etc = path.resolve(conf.get('prefix'), 'etc');
-		conf.root.globalconfig = path.resolve(etc, 'npmrc');
-		conf.root.globalignorefile = path.resolve(etc, 'npmignore');
-	}
-
-	warnings.push(conf.addFile(conf.get('globalconfig'), 'global'));
+	warnings.push(conf.addFile(trustedGlobalconfig, 'global'));
 	conf.loadUser();
 
 	const caFile = conf.get('cafile');

--- a/test.js
+++ b/test.js
@@ -31,3 +31,72 @@ test('npm builtin configs require failed', async () => {
 	
 	expect(failedToLoadBuiltInConfig).toBeTruthy();
 })
+
+describe('project/workspace .npmrc cannot redirect trusted user/global config', () => {
+	const fs = require('fs');
+	const os = require('os');
+	const path = require('path');
+
+	let tmpdir;
+	let cwd;
+	let savedEnv;
+	beforeEach(() => {
+		// Neutralize any ambient npm_config_* (e.g. injected when the test runner
+		// itself is launched via npm/npx) so the trusted destinations come only
+		// from the explicit cli/defaults passed below.
+		savedEnv = {};
+		for (const key of Object.keys(process.env)) {
+			if (/^npm_config_/i.test(key)) {
+				savedEnv[key] = process.env[key];
+				delete process.env[key];
+			}
+		}
+		tmpdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'npm-conf-redirect-')));
+		cwd = process.cwd();
+		process.chdir(tmpdir);
+	});
+	afterEach(() => {
+		process.chdir(cwd);
+		Object.assign(process.env, savedEnv);
+		fs.rmSync(tmpdir, { recursive: true, force: true });
+	});
+
+	test('project .npmrc cannot redirect userconfig to a repo-controlled file', () => {
+		const trustedUser = path.join(tmpdir, 'real-user.npmrc');
+		// Repo ships a project .npmrc that redirects userconfig at a repo file,
+		// and that file injects a secret-bearing auth value
+		// (models the GHSA-3qhv-2rgh-x77r bypass).
+		fs.writeFileSync(path.join(tmpdir, '.npmrc'), 'userconfig=evil.npmrc\n');
+		fs.writeFileSync(path.join(tmpdir, 'evil.npmrc'), '//evil.example/:_authToken=leaked\n');
+
+		const { config: conf } = m({ prefix: tmpdir, userconfig: trustedUser });
+
+		// The trusted user source must be the cli one, NOT the repo redirect.
+		expect(conf.sources.user.path).toBe(trustedUser);
+		expect(conf.sources.user.path).not.toBe(path.join(tmpdir, 'evil.npmrc'));
+		// The secret from the repo-controlled file must NOT have been loaded.
+		expect(conf.get('//evil.example/:_authToken')).toBeUndefined();
+	});
+
+	test('project .npmrc cannot redirect the global config via prefix', () => {
+		const trustedUser = path.join(tmpdir, 'real-user.npmrc');
+		const evilEtc = path.join(tmpdir, 'evil-prefix', 'etc');
+		fs.mkdirSync(evilEtc, { recursive: true });
+		fs.writeFileSync(path.join(evilEtc, 'npmrc'), '//evil.example/:_authToken=leaked-global\n');
+		fs.writeFileSync(path.join(tmpdir, '.npmrc'), `prefix=${path.join(tmpdir, 'evil-prefix')}\n`);
+
+		const { config: conf } = m({ prefix: tmpdir, userconfig: trustedUser });
+
+		expect(conf.get('//evil.example/:_authToken')).toBeUndefined();
+	});
+
+	test('a trusted (cli) userconfig is still loaded and its values applied', () => {
+		const trustedUser = path.join(tmpdir, 'real-user.npmrc');
+		fs.writeFileSync(trustedUser, '//registry.example/:_authToken=trusted-token\n');
+
+		const { config: conf } = m({ prefix: tmpdir, userconfig: trustedUser });
+
+		expect(conf.sources.user.path).toBe(trustedUser);
+		expect(conf.get('//registry.example/:_authToken')).toBe('trusted-token');
+	});
+});


### PR DESCRIPTION
## Problem

`@pnpm/npm-conf` resolves which files to load as the trusted **user** and **global** config sources by reading `userconfig`, `globalconfig`, and `prefix` from the *full* config chain — which includes the repository-controlled `project` and `workspace` `.npmrc` layers.

That lets a repository-controlled `.npmrc` redirect those trusted destinations. For example, a checked-out `.npmrc` containing:

```ini
userconfig=.evil-npmrc
```

causes pnpm to load the repo-shipped `.evil-npmrc` as the trusted **user** source. Trusted sources are exempt from the untrusted-env-expansion filtering added for **GHSA-3qhv-2rgh-x77r** and are allowed to set `tokenHelper`, so this is a bypass of that fix: a malicious repository can expand environment secrets (e.g. CI tokens) into a registry request URL or `Authorization` header and exfiltrate them to an attacker-selected registry. `prefix=` similarly redirects the trusted **global** source via the prefix-derived `globalconfig` path.

## Fix

Resolve the user/global config file destinations from the **trusted layers only** (cli, env, builtin, defaults) *before* the `project` and `workspace` `.npmrc` files are added to the config chain, and use those captured destinations when loading the `user` and `global` files.

## Tests

Added regression tests covering:
- project `.npmrc` cannot redirect `userconfig` to a repo-controlled file (secret not loaded),
- project `.npmrc` cannot redirect the global config via `prefix`,
- a trusted (cli) `userconfig` is still loaded and its values applied.

All existing tests continue to pass. The change was also verified end-to-end against pnpm 10.34.2: with the fix, the original exploit no longer reaches the attacker registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security by preventing project configuration files from redirecting trusted user and global configuration settings, protecting against potential unauthorized file access.

* **Tests**
  * Added test coverage to verify trusted configuration settings remain protected against tampering attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->